### PR TITLE
check: add the filter to the source

### DIFF
--- a/check.go
+++ b/check.go
@@ -31,7 +31,7 @@ func Check(request CheckRequest, manager Github) (CheckResponse, error) {
 	log.Println("total pulls found:", len(pulls))
 
 	for _, p := range pulls {
-		if !pullrequest.FromReleaseBranch()(p) {
+		if !pullrequest.FromReleaseBranch(request.Source.ReleaseFilter)(p) {
 			log.Println("Branch of PR is not a release branch, skipping...")
 			continue
 		}

--- a/models.go
+++ b/models.go
@@ -40,6 +40,8 @@ type Source struct {
 	RequiredReviewApprovals int `json:"required_review_approvals,omitempty"`
 	// Labels returns versions for PRs matching labels
 	Labels []string `json:"labels,omitempty"`
+	// ReleaseFilter returns a string used for filtering branches that has the string as a prefix
+	ReleaseFilter string `json:"release_filter"`
 }
 
 // Validate the source configuration.
@@ -50,6 +52,10 @@ func (s *Source) Validate() error {
 
 	if len(s.V3Endpoint)+len(s.V4Endpoint) > 0 && (s.V3Endpoint == "" || s.V4Endpoint == "") {
 		return errors.New("both v3_endpoint & v4_endpoint endpoints are required for GitHub Enterprise")
+	}
+
+	if s.ReleaseFilter == "" {
+		return errors.New("filter for release branches must be specified")
 	}
 
 	return nil

--- a/pullrequest/filter.go
+++ b/pullrequest/filter.go
@@ -23,9 +23,9 @@ const (
 type Filter func(PullRequest) bool
 
 // FromReleaseBranch will check if the PR is from a branch starting with release/*
-func FromReleaseBranch() Filter {
+func FromReleaseBranch(filter string) Filter {
 	return func(p PullRequest) bool {
-		if strings.HasPrefix(p.HeadRefName, "release/") {
+		if strings.HasPrefix(p.HeadRefName, filter) {
 			log.Println("FROM RELEASE BRANCH, SHOULD PRODUCE NEW VERSION...")
 			return true
 		}

--- a/pullrequest/filter.go
+++ b/pullrequest/filter.go
@@ -26,7 +26,6 @@ type Filter func(PullRequest) bool
 func FromReleaseBranch(filter string) Filter {
 	return func(p PullRequest) bool {
 		if strings.HasPrefix(p.HeadRefName, filter) {
-			log.Println("FROM RELEASE BRANCH, SHOULD PRODUCE NEW VERSION...")
 			return true
 		}
 		return false


### PR DESCRIPTION
Don't specify the `prefix` for release branches in the code, add a
parameter to the source so it can be specified.

- Add a new parameter to the source `ReleaseFilter` which will be used
  for filtering the branch name